### PR TITLE
A suggestion for linking to an external blog page

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -6,7 +6,7 @@
 
 * [Home](home.md)
 * [News](news.md)
-* [Blog](http://blog.poseidon-adna.org)
+* [<i class="fa fa-comments" aria-hidden="true"></i> Blog](http://blog.poseidon-adna.org)
 * [Getting started](getting_started.md)
 * [Background](background.md)
 * **<i class="fas fa-clipboard-list" aria-hidden="true"></i>&nbsp; The Poseidon Standard**

--- a/_sidebar.md
+++ b/_sidebar.md
@@ -5,6 +5,8 @@
 </p>
 
 * [Home](home.md)
+* [News](news.md)
+* [Blog](http://blog.poseidon-adna.org)
 * [Getting started](getting_started.md)
 * [Background](background.md)
 * **<i class="fas fa-clipboard-list" aria-hidden="true"></i>&nbsp; The Poseidon Standard**

--- a/home.md
+++ b/home.md
@@ -127,6 +127,8 @@
   </div>
 </div>
 
+# Latest news
+
 <style>
   .grid-container{
     display: grid;
@@ -167,7 +169,7 @@
         const parser = new DOMParser();
         const xmlDoc = parser.parseFromString(xmlString, 'text/xml');
         const items = xmlDoc.querySelectorAll('item');
-        const itemArray = Array.from(items).slice(0, 9);
+        const itemArray = Array.from(items).slice(0, 3);
         const parsedItems = [];
         itemArray.forEach((item) => {
           const dateElement = item.querySelector('pubDate');
@@ -206,6 +208,8 @@
   <div v-else><i>..fetching data from ecoevo.social</i></div>
 
 </div>
+
+[... read more](news.md)
 
 <style>
   .news-grid-element{

--- a/home.md
+++ b/home.md
@@ -127,8 +127,6 @@
   </div>
 </div>
 
-# Latest news
-
 <style>
   .grid-container{
     display: grid;
@@ -147,6 +145,8 @@
     font-size: 30px;
   }
 </style>
+
+### Latest news
 
 <br>
 

--- a/news.md
+++ b/news.md
@@ -48,29 +48,15 @@ Follow us on [Mastodon](https://ecoevo.social/@poseidon)
 <div id="tootViewer">
 
   <div v-if="toots">
-    <div class="grid-container">
-      <div class="news-grid-element" v-for="toot in toots">
+    <ul class="grid-container">
+      <li class="news-grid-element" v-for="toot in toots">
         <div class="news-small-text"><i class="fab fa-mastodon" aria-hidden="true"></i> {{toot.date}}</div>
         <div class="news-small-text"><a :href=toot.link> {{toot.link}}</a></div>
         <div v-html="toot.description"></div>
-      </div>
-    </div>
+      </li>
+    </ul>
   </div>
   
   <div v-else><i>..fetching data from ecoevo.social</i></div>
 
 </div>
-
-<style>
-  .news-grid-element{
-    border-radius: 25px;
-    border: 1px solid;
-    border-color: grey;
-    text-align: left;
-    padding: 15px;
-    overflow-wrap: break-word;
-  }
-  .news-small-text{
-    font-size: 10px;
-  }
-</style>

--- a/news.md
+++ b/news.md
@@ -1,6 +1,6 @@
 # News
 
-Follow us on [Mastodon](https://ecoevo.social/@poseidon)
+Follow us on <a href=https://ecoevo.social/@poseidon>Mastodon <i class="fab fa-mastodon" aria-hidden="true"></i></a> or via <a href=https://ecoevo.social/@poseidon.rss>RSS <i class="fa fa-rss" aria-hidden="true"></i></a>
 
 <script>
   Vue.createApp({
@@ -49,14 +49,29 @@ Follow us on [Mastodon](https://ecoevo.social/@poseidon)
 
   <div v-if="toots">
     <ul class="grid-container">
-      <li class="news-grid-element" v-for="toot in toots">
-        <div class="news-small-text"><i class="fab fa-mastodon" aria-hidden="true"></i> {{toot.date}}</div>
-        <div class="news-small-text"><a :href=toot.link> {{toot.link}}</a></div>
+      <div class="news-grid-element" v-for="toot in toots">
+        <div class="news-small-text"><i class="fab fa-mastodon" aria-hidden="true"></i> {{toot.date}} | <a :href=toot.link>{{toot.link}}</a></div>
         <div v-html="toot.description"></div>
-      </li>
+      </div>
     </ul>
   </div>
   
   <div v-else><i>..fetching data from ecoevo.social</i></div>
 
 </div>
+
+<style>
+  .news-grid-element{
+    border-radius: 25px;
+    border: 1px solid;
+    border-color: grey;
+    text-align: left;
+    padding: 15px;
+    padding-bottom: 0px;
+    overflow-wrap: break-word;
+    margin-bottom: 10px;
+  }
+  .news-small-text{
+    font-size: 10px;
+  }
+</style>

--- a/news.md
+++ b/news.md
@@ -21,7 +21,7 @@ Follow us on [Mastodon](https://ecoevo.social/@poseidon)
         const parser = new DOMParser();
         const xmlDoc = parser.parseFromString(xmlString, 'text/xml');
         const items = xmlDoc.querySelectorAll('item');
-        const itemArray = Array.from(items);
+        const itemArray = Array.from(items).slice(0, 30);
         const parsedItems = [];
         itemArray.forEach((item) => {
           const dateElement = item.querySelector('pubDate');

--- a/news.md
+++ b/news.md
@@ -1,0 +1,76 @@
+# News
+
+Follow us on [Mastodon](https://ecoevo.social/@poseidon)
+
+<script>
+  Vue.createApp({
+    data () {
+     return {
+        toots: null
+      }
+    },
+    async mounted () {
+      const rssResponse = await fetch(
+        "https://ecoevo.social/@poseidon.rss"
+      );
+      const rssData = await rssResponse.text();
+      this.toots = this.parseRSS(rssData);
+    },
+    methods: {
+      parseRSS(xmlString) {
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString(xmlString, 'text/xml');
+        const items = xmlDoc.querySelectorAll('item');
+        const itemArray = Array.from(items);
+        const parsedItems = [];
+        itemArray.forEach((item) => {
+          const dateElement = item.querySelector('pubDate');
+          const linkElement = item.querySelector('link');
+          const descriptionElement = item.querySelector('description');
+          if (dateElement && linkElement && descriptionElement) {
+            const date = dateElement.textContent;
+            const link = linkElement.textContent;
+            const description = descriptionElement.textContent;
+            parsedItems.push({
+              date,
+              link,
+              description,
+            });
+          }
+        });
+
+        return parsedItems;
+      }
+    }
+  }).mount('#tootViewer');
+</script>
+
+<div id="tootViewer">
+
+  <div v-if="toots">
+    <div class="grid-container">
+      <div class="news-grid-element" v-for="toot in toots">
+        <div class="news-small-text"><i class="fab fa-mastodon" aria-hidden="true"></i> {{toot.date}}</div>
+        <div class="news-small-text"><a :href=toot.link> {{toot.link}}</a></div>
+        <div v-html="toot.description"></div>
+      </div>
+    </div>
+  </div>
+  
+  <div v-else><i>..fetching data from ecoevo.social</i></div>
+
+</div>
+
+<style>
+  .news-grid-element{
+    border-radius: 25px;
+    border: 1px solid;
+    border-color: grey;
+    text-align: left;
+    padding: 15px;
+    overflow-wrap: break-word;
+  }
+  .news-small-text{
+    font-size: 10px;
+  }
+</style>


### PR DESCRIPTION
I have recently started a simple quarto-based blog [here](https://github.com/poseidon-framework/poseidon-blog/), which is now deployed into http://blog.poseidon-adna.org (HTTPS is coming). 

I also created a separate `news` page which lists all Mastodon posts (this could be too much at some point, to be discussed). The front page only shows three posts now, teasing for more with a link to the news page.