### PR TITLE
Add community page

### DIFF
--- a/home.md
+++ b/home.md
@@ -143,7 +143,7 @@
       </span>
     </button>
     <button onclick="window.open(
-      'https://matrix.to/#/#poseidon-adna:gitter.im',
+      'https://app.gitter.im/#/room/!TycQipeBdEPTHWqilU:gitter.im',
       '_blank');;"
       class="button">
       <span>
@@ -155,7 +155,7 @@
 
 Poseidon was founded and been mainly developed by entusiasts at the [Max Planck Institute for Evolutionary Anthropology in Leipzig](https://www.eva.mpg.de/archaeogenetics/projects/poseidon/), but it seeks to foster a growing community of users, package maintainers and developers. There are multiple ways you can get involved:
 
-* Join our [Gitter channel](https://matrix.to/#/#poseidon-adna:gitter.im) to ask questions or make suggestions
+* Join our [Gitter channel](https://app.gitter.im/#/room/!TycQipeBdEPTHWqilU:gitter.im) to ask questions or make suggestions
 * Use our software and report issues on github, for example for trident [here](https://github.com/poseidon-framework/poseidon-hs/issues) and for xerxes [here](https://github.com/poseidon-framework/poseidon-analysis-hs/issues)
 * Use our data and report issues on github for the [Poseidon Community Archive](https://github.com/poseidon-framework/community-archive/issues), the [Poseidon Minotaur archive](https://github.com/poseidon-framework/minotaur-archive/issues) and the [Poseidon AADR archive](https://github.com/poseidon-framework/aadr-archive/issues).
 * Contribute packages to the Community Archive (see [Contribution Guide](archive_submission_guide.md)) or fix issues with existing packages, or contribute new recipes for Minotaur (see [recipes repository](https://github.com/poseidon-framework/minotaur-recipes))

--- a/home.md
+++ b/home.md
@@ -125,6 +125,7 @@
 
 <div id="landingPageButtonsOuter">
   <div id="landingPageButtonsInner">
+  Find us on
     <button onclick="window.open(
       'https://github.com/poseidon-framework',
       '_blank');;"
@@ -141,16 +142,24 @@
         <i class="fab fa-mastodon" aria-hidden="true"></i> Mastodon
       </span>
     </button>
+    <button onclick="window.open(
+      'https://matrix.to/#/#poseidon-adna:gitter.im',
+      '_blank');;"
+      class="button">
+      <span>
+        <i class="fab fa-gitter" aria-hidden="true"></i> Gitter
+      </span>
+    </button>
   </div>
 </div>
 
 Poseidon was founded and been mainly developed by entusiasts at the [Max Planck Institute for Evolutionary Anthropology in Leipzig](https://www.eva.mpg.de/archaeogenetics/projects/poseidon/), but it seeks to foster a growing community of users, package maintainers and developers. There are multiple ways you can get involved:
 
-1.) Join our Gitter channel (...) to ask questions or make suggestions
-2.) Use our software and report issues on github, for example for trident [here](https://github.com/poseidon-framework/poseidon-hs/issues) and for xerxes [here](https://github.com/poseidon-framework/poseidon-analysis-hs/issues)
-3.) Use our data and report issues on github for the [Poseidon Community Archive](https://github.com/poseidon-framework/community-archive/issues), the [Poseidon Minotaur archive](https://github.com/poseidon-framework/minotaur-archive/issues) and the [Poseidon AADR archive](https://github.com/poseidon-framework/aadr-archive/issues).
-4.) Contribute packages to the Community Archive (see [Contribution Guide](archive_submission_guide.md)) or fix issues with existing packages, or contribute new recipes for Minotaur (see [recipes repository](https://github.com/poseidon-framework/minotaur-recipes))
-5.) Join the growing [HAAM community](https://haam-community.github.io) to meet other researchers interested in archaeogenetic data analyses.
+* Join our [Gitter channel](https://matrix.to/#/#poseidon-adna:gitter.im) to ask questions or make suggestions
+* Use our software and report issues on github, for example for trident [here](https://github.com/poseidon-framework/poseidon-hs/issues) and for xerxes [here](https://github.com/poseidon-framework/poseidon-analysis-hs/issues)
+* Use our data and report issues on github for the [Poseidon Community Archive](https://github.com/poseidon-framework/community-archive/issues), the [Poseidon Minotaur archive](https://github.com/poseidon-framework/minotaur-archive/issues) and the [Poseidon AADR archive](https://github.com/poseidon-framework/aadr-archive/issues).
+* Contribute packages to the Community Archive (see [Contribution Guide](archive_submission_guide.md)) or fix issues with existing packages, or contribute new recipes for Minotaur (see [recipes repository](https://github.com/poseidon-framework/minotaur-recipes))
+* Join the growing [HAAM community](https://haam-community.github.io) to meet other researchers interested in archaeogenetic data analyses.
 
 ### Latest news
 

--- a/home.md
+++ b/home.md
@@ -22,23 +22,6 @@
         <i class="fa fa-play-circle" aria-hidden="true"></i> Quick start guide
       </span>
     </button>
-    &nbsp;
-    <button onclick="window.open(
-      'https://github.com/poseidon-framework',
-      '_blank');;"
-      class="button">
-      <span>
-        <i class="fab fa-github" aria-hidden="true"></i> GitHub
-      </span>
-    </button>
-    <button onclick="window.open(
-      'https://ecoevo.social/@poseidon',
-      '_blank');;"
-      class="button">
-      <span>
-        <i class="fab fa-mastodon" aria-hidden="true"></i> Mastodon
-      </span>
-    </button>
   </div>
 </div>
 
@@ -137,6 +120,37 @@
     font-size: 30px;
   }
 </style>
+
+### Community
+
+<div id="landingPageButtonsOuter">
+  <div id="landingPageButtonsInner">
+    <button onclick="window.open(
+      'https://github.com/poseidon-framework',
+      '_blank');;"
+      class="button">
+      <span>
+        <i class="fab fa-github" aria-hidden="true"></i> GitHub
+      </span>
+    </button>
+    <button onclick="window.open(
+      'https://ecoevo.social/@poseidon',
+      '_blank');;"
+      class="button">
+      <span>
+        <i class="fab fa-mastodon" aria-hidden="true"></i> Mastodon
+      </span>
+    </button>
+  </div>
+</div>
+
+Poseidon was founded and been mainly developed by entusiasts at the [Max Planck Institute for Evolutionary Anthropology in Leipzig](https://www.eva.mpg.de/archaeogenetics/projects/poseidon/), but it seeks to foster a growing community of users, package maintainers and developers. There are multiple ways you can get involved:
+
+1.) Join our Gitter channel (...) to ask questions or make suggestions
+2.) Use our software and report issues on github, for example for trident [here](https://github.com/poseidon-framework/poseidon-hs/issues) and for xerxes [here](https://github.com/poseidon-framework/poseidon-analysis-hs/issues)
+3.) Use our data and report issues on github for the [Poseidon Community Archive](https://github.com/poseidon-framework/community-archive/issues), the [Poseidon Minotaur archive](https://github.com/poseidon-framework/minotaur-archive/issues) and the [Poseidon AADR archive](https://github.com/poseidon-framework/aadr-archive/issues).
+4.) Contribute packages to the Community Archive (see [Contribution Guide](archive_submission_guide.md)) or fix issues with existing packages, or contribute new recipes for Minotaur (see [recipes repository](https://github.com/poseidon-framework/minotaur-recipes))
+5.) Join the growing [HAAM community](https://haam-community.github.io) to meet other researchers interested in archaeogenetic data analyses.
 
 ### Latest news
 


### PR DESCRIPTION
So, I took your initiative to remove the Slack link, @nevrome, and developed it further to add some more notes on Community on the front page. Currently it's a bit verbose and ugly. Perhaps we can make these into buttons or something? 

I also find it important to not just point to our GitHub presence, but also explicitly point out the different channels to contribute on GitHub: reporting Issues on Software, reportin Issues with the data, contributing new recipes, contributing packages, maintaining packages etc. Perhaps we find an elegant way to list those succinctly? Or we group the various GitHub channels within a "Contribute" area, much like the three areas above?